### PR TITLE
GC installation typo fix (buttons cable -> connectors)

### DIFF
--- a/src/pages/docs/installation-gc.mdx
+++ b/src/pages/docs/installation-gc.mdx
@@ -391,7 +391,7 @@ Plug the female connector of the <u>grey U-cable</u> into the now free PMP.A soc
 
 In order to keep the switches operational, plug in the <u>Buttons cable</u> into the switches section as follows:
 Green  BREW to C.1
-Green STEAM to S.2
+Green STEAM to S.1
 Black Gnd to C.2
 Black Gnd to S.2
 


### PR DESCRIPTION
While going through the Gaggia classic installation process I found an error/typo in the button cable connector naming.