### PR TITLE
Add pressure transducer connection instructions for Pro rev. 1.1

### DIFF
--- a/src/pages/docs/installation-silvia.mdx
+++ b/src/pages/docs/installation-silvia.mdx
@@ -262,6 +262,8 @@ The green wires should go to where you removed C.2 and S.1, the black wires to w
 Connect all the wires to the PCB like in the picture and place it on top of the SSR at the front of the machine. Make sure there are no wires underneath the casing or the front panel won't fit.
 Run the display power cable out the top of the case.
 
+If using rev. 1.1 of the Gaggimate Pro, the PCB connector for the pressure transducer will have four openings, rather than three as pictured above. Facing the PCB connector from the side with orange levers, the pressure transducer connects as follows (left to right): Black (ground), Open (no connection), Green (analog in), Red (+5V).
+
 #### Screen
 
 Run the red/black cable from the PCB to the screen and connect it to the 4 pin connector. The cable has enough space to be routed between the cup warmer and casing. The screen casing simply sits on the edge of the housing.


### PR DESCRIPTION
This information is available on the Pinout page, but the instructions don't address the difference.